### PR TITLE
implement replace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ sys     0m0.033s
 noderify
   -f mod                # excludes mod from the bundle
   -p prelude.js         # specify a custom prelude file (see nodepack's implementation for reference)
+  --filter module_name1
+                        # exclude this module from the bundle, use for native addons. (may be repeated)
+  --replace.module_name=new-module-name
+                        # map one module to another.
+```
+
+since `noderify` uses `rc` it configuration may be set in a local `.noderifyrc` file in json format.
+
+``` js
+{
+  "filter": ["module_name1", "module_name2"],
+  "replace": {
+    "sodium-native": "sodium-javascript"
+  }
+}
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var path = require('path')
 var join = path.join
 var fs = require('fs')
 
+
 // io.js native modules
 var native_modules = [
   'assert', 'buffer', 'child_process', 'cluster', 'console',
@@ -22,6 +23,7 @@ var electron_modules = [
   'native-image', 'screen', 'shell'
 ]
 
+
 var argv = require('minimist')(process.argv.slice(2), {
   alias: {
     f: 'filter',
@@ -33,26 +35,28 @@ var argv = require('minimist')(process.argv.slice(2), {
   boolean: ['electron', 'version']
 })
 
-if(argv.electron) argv.shebang = false
+//startup noderify with optimist's defaults
+var opts = require('rc')('noderify', {}, argv)
 
-if(argv.version)
+if(opts.electron) argv.shebang = false
+
+if(opts.version)
   return console.log(require('./package.json').version)
 
-var filter = [].concat(argv.filter)
+var filter = [].concat(opts.filter)
               .concat(native_modules)
-              .concat(argv.electron ? electron_modules : [])
+              .concat(opts.electron ? electron_modules : [])
 
-if(!argv._[0]) {
+console.error("OPTS", opts)
+
+if(!opts._[0]) {
   console.error('usage: noderify entry.js > bundle.js')
   process.exit(1)
 }
 
-var entry = path.resolve(argv._[0])
+var entry = opts.entry || path.resolve(opts._[0])
 
-var replace = {}
-
-if(argv.shebang !== false)
-  console.log('#! /usr/bin/env node')
+//var replace = {}
 
 //deps
 //  .pipe(deterministic(function (err, content, deps, entry) {
@@ -65,9 +69,14 @@ if(argv.shebang !== false)
 require('./inject')({
   entry: entry,
   filter: filter,
-  replace: argv.replace || {},
-  ignoreMissing: argv.ignoreMissing
+  replace: opts.replace || {},
+  ignoreMissing: opts.ignoreMissing
 }, function (err, src) {
   if(err) throw err
   console.log(src)
 })
+
+
+
+
+

--- a/index.js
+++ b/index.js
@@ -3,12 +3,6 @@
 var path = require('path')
 var join = path.join
 var fs = require('fs')
-var moduleDeps = require('module-deps')
-var resolve = require('resolve')
-var through = require('through2')
-var sort = require('sort-stream')
-var deterministic = require('./deterministic')
-var pack = require('./pack')
 
 // io.js native modules
 var native_modules = [
@@ -48,32 +42,6 @@ var filter = [].concat(argv.filter)
               .concat(native_modules)
               .concat(argv.electron ? electron_modules : [])
 
-function exists (p) {
-  try {
-    (fs.accessSync || fs.statSync)(p)
-    return true
-  } catch (err) {
-    return false
-  }
-}
-
-function pkgRoot (file) {
-  var dir = path.dirname(file)
-    , prev
-  while (true) {
-    if (exists(join(dir, 'package.json')) || exists(join(dir, 'node_modules')))
-      return dir
-
-    if (prev === dir) {
-      throw new Error('Could not find module root for ' + file)
-    }
-
-    prev = dir
-    dir = join(dir, '..')
-  }
-}
-
-
 if(!argv._[0]) {
   console.error('usage: noderify entry.js > bundle.js')
   process.exit(1)
@@ -82,93 +50,24 @@ if(!argv._[0]) {
 var entry = path.resolve(argv._[0])
 
 var replace = {}
-var deps = moduleDeps({
-  ignoreMissing: argv.ignoreMissing,
-  globalTransform: function (file, opts) {
-    return through(function (chunk, enc, cb) {
-      chunk += ''
-      var s = this
-      var m = chunk.match(/require\(.bindings.\)\(.([\-_a-zA-Z0-9.]+).\)/)
-      if (m) {
-        var basedir = pkgRoot(file)
-        var n = m[1].substr(-5) === '.node' ? m[1] : m[1]+ '.node'
-        resolve('./build/Release/'+n, {basedir: pkgRoot(file), extensions: ['.node']},
-          function (err, p) {
-            chunk = chunk.replace(m[0], "require('./"+path.relative(basedir, p)+"')")
-            s.push(chunk)
-            cb()
-          })
-      } else {
-        s.push(chunk)
-        cb()
-      }
-    })
-  },
-  filter: function (s) {
-    return !~filter.indexOf(s)
-  },
-  resolve: function (a, b, cb) {
-    return resolve (a, {
-        basedir: path.dirname(b.filename),
-        extensions: ['.js', '.json', '.node']
-      },
-      function (err, file) {
-        if(err) return cb (err)
-        if (file) {
-          if (file[0] !== '/') {
-            var c = a.split('/')[0]
-            if (c[0] !== '.') console.error('missing dependency. need to install:', c)
-          } else if (file && file.substr(-5) === '.node') {
-            replace[a] = path.relative(path.dirname(entry), file)
-            return cb(null, null)
-          }
-        }
-
-        cb(null, /^\//.test(file) ? file : null)
-    })
-  },
-  postFilter: function (id, file, pkg) {
-    if(/\.node$/.test(id)) console.error(id, file)
-    //console.error(id, file)
-    return file || !(/\.node$/.test(id))
-    //return true
-    console.error(id, file, pkg)
-    return !!file
-  }
-})
-  .on('data', function (e) {
-    e.id = path.relative(process.cwd(), e.id)
-    e.source = e.source.replace(/^\s*#![^\n]*/, '\n')
-    // secret magic sauce
-    for (var id in replace) {
-      e.source = e.source.replace(new RegExp("require\\(\\'"+id+"\\'\\)", 'g'), "require('./"+replace[id]+"')")
-    }
-
-    try {
-      JSON.parse(e.source)
-      e.source = 'module.exports = ' + e.source
-    } catch (e) { }
-
-    for(var k in e.deps) {
-      // console.error(e.id, k, e.deps[k])
-      if(!e.deps[k])
-        delete e.deps[k]
-      else
-        e.deps[k] = path.relative(process.cwd(), e.deps[k])
-    }
-  })
 
 if(argv.shebang !== false)
   console.log('#! /usr/bin/env node')
 
-deps
-  .pipe(deterministic(function (err, content, deps, entry) {
-      if(err) throw err
-      console.log(pack(content, deps, entry))
-    }))
+//deps
+//  .pipe(deterministic(function (err, content, deps, entry) {
+//      if(err) throw err
+//      console.log(pack(content, deps, entry))
+//    }))
+//
+//deps.end(entry)
 
-deps.end(entry)
-
-
-
-
+require('./inject')({
+  entry: entry,
+  filter: filter,
+  replace: argv.replace || {},
+  ignoreMissing: argv.ignoreMissing
+}, function (err, src) {
+  if(err) throw err
+  console.log(src)
+})

--- a/inject.js
+++ b/inject.js
@@ -1,0 +1,134 @@
+var moduleDeps = require('module-deps')
+var resolve = require('resolve')
+var through = require('through2')
+var sort = require('sort-stream')
+var deterministic = require('./deterministic')
+var pack = require('./pack')
+var path = require('path')
+var fs = require('fs')
+
+function exists (p) {
+  try {
+    (fs.accessSync || fs.statSync)(p)
+    return true
+  } catch (err) {
+    console.error('not fonid', p, err)
+    return false
+  }
+}
+
+function pkgRoot (file) {
+  var dir = path.dirname(file)
+    , prev
+
+  while (true) {
+    console.error('PKG_ROOT', dir)
+    if (exists(path.join(dir, 'package.json')) || exists(path.join(dir, 'node_modules')))
+      return dir
+
+    if (prev === dir) {
+      throw new Error('Could not find module root for ' + file)
+    }
+
+    prev = dir
+    dir = path.join(dir, '..')
+  }
+}
+
+
+
+function createDepStream(opts) {
+
+  return moduleDeps({
+    ignoreMissing: opts.ignoreMissing,
+//    globalTransform: function (file, opts) {
+//      return through(function (chunk, enc, cb) {
+//        chunk += ''
+//        var s = this
+//        var m = chunk.match(/require\(.bindings.\)\(.([\-_a-zA-Z0-9.]+).\)/)
+//        if (m) {
+//          var basedir = pkgRoot(file)
+//          var n = m[1].substr(-5) === '.node' ? m[1] : m[1]+ '.node'
+//          resolve('./build/Release/'+n, {basedir: pkgRoot(file), extensions: ['.node']},
+//            function (err, p) {
+//              chunk = chunk.replace(m[0], "require('./"+path.relative(basedir, p)+"')")
+//              s.push(chunk)
+//              cb()
+//            })
+//        } else {
+//          s.push(chunk)
+//          cb()
+//        }
+//      })
+//    },
+    filter: function (s) {
+      return !~opts.filter.indexOf(s)
+    },
+    resolve: function (required, module, cb) {
+//      console.error(opts.replace)
+      if(opts.replace && opts.replace[required]) {
+        required = opts.replace[required]
+      }
+      return resolve (required, {
+          basedir: path.dirname(module.filename),
+          extensions: ['.js', '.json', '.node']
+        },
+        function (err, file) {
+          if(err) return cb (err)
+          if (file) {
+            if (file[0] !== '/') {
+              var c = required.split('/')[0]
+              if (c[0] !== '.') console.error('missing dependency. need to install:', c)
+            } else if (file && file.substr(-5) === '.node') {
+              opts.replace[required] = path.relative(path.dirname(opts.entry), file)
+              return cb(null, null)
+            }
+          }
+
+          cb(null, /^\//.test(file) ? file : null)
+      })
+    },
+    postFilter: function (id, file, pkg) {
+      if(/\.node$/.test(id)) console.error(id, file)
+      return file || !(/\.node$/.test(id))
+      //return true
+      console.error(id, file, pkg)
+      return !!file
+    }
+  })
+    .on('data', function (e) {
+      e.id = path.relative(process.cwd(), e.id)
+      e.source = e.source.replace(/^\s*#![^\n]*/, '\n')
+      // secret magic sauce
+//      for (var id in opts.replace) {
+//        e.source = e.source.replace(new RegExp("require\\(\\'"+id+"\\'\\)", 'g'), "require('./"+opts.replace[id]+"')")
+//      }
+
+      try {
+        JSON.parse(e.source)
+        e.source = 'module.exports = ' + e.source
+      } catch (e) { }
+
+      for(var k in e.deps) {
+        // console.error(e.id, k, e.deps[k])
+        if(!e.deps[k])
+          delete e.deps[k]
+        else
+          e.deps[k] = path.relative(process.cwd(), e.deps[k])
+      }
+    })
+}
+
+module.exports = function (opts, cb) {
+  var deps = createDepStream(opts)
+  deps
+  .pipe(deterministic(function (err, content, deps, entry) {
+      if(err) cb(err)
+      else cb(null, pack(content, deps, entry))
+    }))
+
+  deps.end(opts.entry)
+
+}
+
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "through2": "^2.0.0"
   },
   "bin": "./bin.js",
-  "devDependencies": {},
+  "devDependencies": {
+    "leveldown": "^1.7.2",
+    "sodium-native": "^1.10.2"
+  },
   "scripts": {
     "prepublish": "./test/index.sh && ./index.js index.js > bin.js && npm ls",
     "test": "./test/index.sh"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "minimist": "^1.1.2",
     "module-deps": "^4.0.7",
+    "rc": "^1.1.6",
     "resolve": "^1.1.6",
     "sort-stream": "^1.0.1",
     "through2": "^2.0.0"

--- a/test/fbb.js
+++ b/test/fbb.js
@@ -1,0 +1,6 @@
+
+
+//test replacing foo-bar-baz
+
+console.log('test wether a replaced module actually loads submodules!')
+console.log(require('util').inspect(require('../package.json')))

--- a/test/index.sh
+++ b/test/index.sh
@@ -59,7 +59,14 @@ $noderify test/missing.js --replace.foo-bar-baz=./fbb > _bundle.js
 was_okay
 okay node _bundle.js
 
+
+
 $noderify test/native.js --filter sodium-native --filter leveldown > _bundle.js 
+was_okay
+okay node _bundle.js
+
+echo "replace another way"
+$noderify test/native.js --no-replace.sodium-native --no-replace.leveldown > _bundle.js 
 was_okay
 okay node _bundle.js
 
@@ -84,6 +91,7 @@ echo "ignore missing"
 okay node _b.js missing.js --ignore-missing 2> /dev/null > /dev/null
 
 tidy
+
 
 
 

--- a/test/index.sh
+++ b/test/index.sh
@@ -4,8 +4,7 @@
 # use noderify to bundle itself, then check that the bundled
 # version can still bundle noderify and get the exact same bundle.
 
-okay () {
-  "$@"
+was_okay () {
   if [ $? -eq 0 ]; then
     echo Okay
   else
@@ -13,6 +12,12 @@ okay () {
     exit 1
   fi
 }
+
+okay () {
+  "$@"
+  was_okay
+}
+
 
 not_okay () {
   "$@"
@@ -36,14 +41,30 @@ echo $PWD
 tidy
 
 noderify=./index.js
-for file in test/*.js; do
+#//
+#//  echo $noderify  "$file"
+#//  time $noderify "$file" > _bundle.js
+#//
+#//  okay node _bundle.js
 
-  echo $noderify  "$file"
-  time $noderify "$file" > _bundle.js
+echo "Test module not found error:"
+not_okay $noderify test/missing.js > /dev/null
 
-  okay node _bundle.js
+$noderify test/self-reference.js > _bundle.js 
+was_okay
+okay node _bundle.js
 
-done
+echo "TEST NOT FOUND, but replace missing module"
+$noderify test/missing.js --replace.foo-bar-baz=./fbb > _bundle.js 
+was_okay
+okay node _bundle.js
+
+$noderify test/native.js --filter sodium-native --filter leveldown > _bundle.js 
+was_okay
+okay node _bundle.js
+
+
+#done
 
 #set -e # exit with an error if any command fails
 
@@ -59,8 +80,10 @@ shasum _b.js _b2.js
 okay diff _b.js _b2.js
 
 not_okay node _b.js missing.js  2> /dev/null > /dev/null
+echo "ignore missing"
 okay node _b.js missing.js --ignore-missing 2> /dev/null > /dev/null
 
 tidy
+
 
 

--- a/test/native.js
+++ b/test/native.js
@@ -1,0 +1,3 @@
+
+require('sodium-native')
+require('leveldown')


### PR DESCRIPTION
This implements a replace option,

``` 
noderify entry.js --replace.foo=bar > output.js
```
will load `bar` module where ever it would have otherwise loaded `foo`. since it uses `rc` you can just have a `.noderifyrc` in your project's directory and get the same effect:

``` js
{
  "replace": {"foo": "bar"}
}
```

This may break old behavior around .node files. I can't really remember how that worked,
and there were no tests for that, and those modules normally do clever stuff (like, when I wrote this, the new better way of bundling all the prebuilds didn't exist!) so I've just killed that bit, but you can get that by filtering the native modules you use. but anyway, I'll make this a major version just incase.

@heavyk @0x00a @staltz