### PR TITLE
update module-deps to 6.1.0, and others deps too

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "minimist": "^1.1.2",
-    "module-deps": "^4.0.7",
+    "module-deps": "~6.1.0",
     "rc": "^1.1.6",
-    "resolve": "^1.1.6",
+    "resolve": "~1.7.1",
     "sort-stream": "^1.0.1",
-    "through2": "^2.0.0"
+    "through2": "~2.0.3"
   },
   "bin": "./bin.js",
   "devDependencies": {


### PR DESCRIPTION
Context: I was using async/await in a Scuttlebot plugin, and that's an ES2017 feature supported in Node.js 8.10+. It turns out the chain of dependencies in noderify would already support these features. The actual parsing of JS files is done by [acorn](https://discuss.ternjs.net/t/acorn-release-4-0-0/67), and the chain of dependencies is `noderify > module-deps > detective > acorn`. Updating `module-deps` to 6.1.0 uses a new version of `detective` which by [default now supports](https://github.com/browserify/detective/blob/3ec100f56fc568675a6e33cd14314953822a45d5/index.js#L10) ES2018 (== ES9).

I ran tests, they pass.

It's important to produce `bin.js` after this is merged, and release a new version. I'll release `@staltz/noderify` on npm so I'm not pending on this getting merged.